### PR TITLE
Remove "valid" value from status prop

### DIFF
--- a/src/Textfield/props.ts
+++ b/src/Textfield/props.ts
@@ -11,7 +11,7 @@ type InputType = (typeof inputTypes)[number];
 const sizes = ["wide", "compact"] as const;
 type Size = (typeof sizes)[number];
 
-const status = ["valid", "invalid", "pending"] as const;
+const status = ["invalid", "pending"] as const;
 type Status = (typeof status)[number];
 
 const parameters = {

--- a/src/Textfield/stories/TextfieldController.tsx
+++ b/src/Textfield/stories/TextfieldController.tsx
@@ -23,13 +23,10 @@ const TextfieldController = (props: ITextfield) => {
 
   const onBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
     const isValid = isAlphabetical(e.target.value);
-    setForm({ ...form, status: isValid ? "valid" : "invalid" });
+    setForm({ ...form, status: isValid ? "pending" : "invalid" });
   };
 
-  const message =
-    form.status === "valid"
-      ? "The field has been successfully validated"
-      : "(Please enter only letters in this field)";
+  const message = "(Please enter only letters in this field)";
 
   return (
     <Textfield


### PR DESCRIPTION
This pull request encompasses the removal of the 'valid' value option from the status prop across specific UI components within our application. Aimed at simplifying the component interface and enhancing usability, this update aligns with our initiative to streamline prop configurations and maintain consistency in indicating component states.